### PR TITLE
Change suggestion from project.toml to Manifest.toml

### DIFF
--- a/sample-language-report.md
+++ b/sample-language-report.md
@@ -108,7 +108,7 @@ If data are provided in Numbers of Mathematica files:
 
 > [REQUIRED] Please provide a `requirements.txt` or `environment.yml` file  to   install all Python dependencies. Please specify all necessary commands (a link to the `[pip freeze](https://pip.pypa.io/en/stable/reference/pip_freeze/)` or `[conda env export](https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html#sharing-an-environment)` reference may suffice).
 
-> [REQUIRED] Please provide a `project.toml` file to specify all dependencies for Julia. Some guidance is provided at the [QuantEcon](https://julia.quantecon.org/more_julia/tools_editors.html#Package-Environments) website. Alternatively, add a setup program that installs all Julia package, specifying all necessary commands. An example of a setup file can be found at [https://github.com/labordynamicsinstitute/paper-template/blob/master/programs/packages.jl](https://github.com/labordynamicsinstitute/paper-template/blob/master/programs/packages.jl)
+> [REQUIRED] Please provide a `Manifest.toml` file to specify all dependencies for Julia. Some guidance is provided at the [QuantEcon](https://julia.quantecon.org/more_julia/tools_editors.html#Package-Environments) website. Alternatively, add a setup program that installs all Julia package, specifying all necessary commands. An example of a setup file can be found at [https://github.com/labordynamicsinstitute/paper-template/blob/master/programs/packages.jl](https://github.com/labordynamicsinstitute/paper-template/blob/master/programs/packages.jl)
 
 
 > [REQUIRED] Please provide debugged code, addressing the issues identified in this report.


### PR DESCRIPTION
Thank you for adding Julia recommendations to your guide! I am very happy with the effort the AER has put into data transparency. 

This PR just changes the recommendation from adding a `project.toml` to adding a `Manifest.toml`. 

In general, `Project.toml`s are used for packages that are not the "end result" analysis. Let's say I write a package `MyPackage` which depends on dependency `DependencyPackage`

In this explanation, `MyPackage` is the codebase for an economics paper. In Julia, a "end result" analysis codebase and a pacakge which is used as a tool, say, `DataFrames.jl` are treated the same by the package management system, which is why developers have to be very specific about using `Project.toml` versus a `Manifest.toml`. 

## `Project.toml`

The `Project.toml` specifies versions `1.4-1.6` of `DependencyPackage` and all minor versions in between. Now imagine that a user wants to have another package `ExtraPackage` in their environment alongside `MyPackage`. `ExtraPackage` is not a dependency of `MyPackage` and so wasn't loaded when `MyPackage` was being developed. 

Let's say `ExtraPackage` *also* depends on `DependencyPackage`, and it requires versions `1.4.0-1.4.9` of `DependencyPackage` and all versions in between. Because there is a non-empty subset between the compatability bounds of `MyPackage` and `ExtraPackage`, everything will work.`MyPackage` and `ExtraPackage` will both share version `1.4.9` of `DependencyPackage`. 

This is great if your package is a "tool". It is meant to be used in an environment with other packages loaded. However without proper maintenance and testing, this can lead to bugs. For example, say the economist writing `MyPackage` developed it using version `1.5.6` of `DependencyPackage`. 

They didn't test `MyPackage`  where `DendencyPackage` was set at `1.4.9`, even though there are functions used inside `MyPackage` that did not exist `1.4.9`. They *should* have edited their `Project.toml` toe exclude versions `1.4.9` and below, but they didn't. 

Now, when the user wants to add `ExtraPackage` to their environment, `MyPackage` will break! We can't expect economists to keep track of all of this. Better to have them use a `Manifest.toml`. 

## `Manifest.toml`: 

The `Manifest.toml` specifies version `1.5.6` of `DependencyPackage` (or even a specific commit on `master`) and will not allow any other versions. 

That means if the user wants to load `ExtraPackage`, Julia will error. The intersection between the compatability bounds of `DependencyPackage` for `MyPacakge` and `ExtraPackage` is empty. There is no version of `DependencyPackage` they can both share. 

This is fine! En economic paper is not a "tool". It is an end result in and of itself. There is no expectation that users would ever want to load any other package alongside it. And you gain the benefit of knowing that the versions you are using are *exactly* the ones that were used when developing the package. 